### PR TITLE
set region

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -44,7 +44,7 @@ exports.get_active_logs = functions.https.onRequest(async (req, res) => {
     res.status(200).send(response);
   });
 
-exports.get_time = functions.https.onRequest((req, res) => {
+exports.get_time = functions.region('asia-northeast1').https.onRequest((req, res) => {
     const now = Date.now();
     res.status(200).send({time:now});
   });


### PR DESCRIPTION
get_time function run on tokyo region

時刻サーバ機能を日本時間に統一したいため、リージョンを東京に指定。
https://firebase.google.com/docs/functions/locations?hl=ja
とかを参考に確認ください。

よろしくお願いします。